### PR TITLE
Eliminate the ECONNREFUSED tests

### DIFF
--- a/tests/functional/nix.rs
+++ b/tests/functional/nix.rs
@@ -280,13 +280,14 @@ mod connect {
     use super::*;
 
     #[test]
-    fn econnrefused() {
+    fn eaddrnotavail() {
         let mut cap_net = {
             let mut casper = CASPER.get().unwrap().lock().unwrap();
             casper.net().unwrap()
         };
 
-        let want = get_local_in();
+        // 127.100.0.1 is reserved for local use, but most likely not assigned
+        let want = SockaddrIn::new(127, 100, 0, 1, crate::next_port());
 
         let client_sock = socket(
             AddressFamily::Inet,
@@ -296,7 +297,7 @@ mod connect {
         )
         .unwrap();
         let e = cap_net.connect(&client_sock, &want).unwrap_err();
-        assert_eq!(Error::ECONNREFUSED, e);
+        assert_eq!(Error::EADDRNOTAVAIL, e);
     }
 
     #[test]

--- a/tests/functional/std.rs
+++ b/tests/functional/std.rs
@@ -95,15 +95,20 @@ mod tcp_stream {
         use super::*;
 
         #[test]
-        fn econnrefused() {
+        fn eaddrnotavail() {
             let mut cap_net = {
                 let mut casper = CASPER.get().unwrap().lock().unwrap();
                 casper.net().unwrap()
             };
 
-            let want = get_local_in();
+            // 127.100.0.1 is reserved for local use, but most likely not assigned
+            let want: SocketAddr = SocketAddrV4::new(
+                Ipv4Addr::new(127, 100, 0, 1),
+                crate::next_port(),
+            )
+            .into();
             let err = TcpStream::cap_connect(&mut cap_net, want).unwrap_err();
-            assert_eq!(err.raw_os_error(), Some(libc::ECONNREFUSED));
+            assert_eq!(err.raw_os_error(), Some(libc::EADDRNOTAVAIL));
         }
 
         #[test]


### PR DESCRIPTION
In CI, these tests sometimes fail with ETIMEDOUT instead.  Maybe firewall settings in GCE?  Instead, use EADDRNOTAVAIL to get test coverage for those error paths.