### PR TITLE
ci: update FreeBSD workflow values to 15.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Start VM
         uses: vmactions/freebsd-vm@v1
         with:
-          release: ${{ matrix.freebsd_version }}
+          release: 15.1
           usesh: true
       - name: Install dependencies
         shell: freebsd {0}
@@ -65,7 +65,7 @@ jobs:
       - name: Start VM
         uses: vmactions/freebsd-vm@v1
         with:
-          release: "14.4"
+          release: 15.1
           usesh: true
       - name: Install dependencies
         shell: freebsd {0}
@@ -94,7 +94,7 @@ jobs:
       - name: Start VM
         uses: vmactions/freebsd-vm@v1
         with:
-          release: "14.4"
+          release: 15.1
           usesh: true
       - name: Install dependencies
         shell: freebsd {0}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
             rust_version: nightly
             target: x86_64-unknown-freebsd
             arch: x86_64
-          - freebsd_version: "15.0"
+          - freebsd_version: "15.1"
             rust_version: nightly
             target: x86_64-unknown-freebsd
             arch: x86_64
@@ -37,7 +37,7 @@ jobs:
       - name: Start VM
         uses: vmactions/freebsd-vm@v1
         with:
-          release: 15.1
+          release: ${{ matrix.freebsd_version }}
           usesh: true
       - name: Install dependencies
         shell: freebsd {0}


### PR DESCRIPTION
Updates .github/workflows/ci.yml to use FreeBSD 15.1 by changing the matrix `freebsd_version` entry to 15.1 and updating the already hard-coded `release` values to 15.1.